### PR TITLE
Fix table of contents not compiling.

### DIFF
--- a/pylatex/document.py
+++ b/pylatex/document.py
@@ -231,6 +231,10 @@ class Document(Environment):
             try:
                 output = subprocess.check_output(command,
                                                  stderr=subprocess.STDOUT)
+                # second pass fix issue with Table of Contents (TOC) not compiling.
+                output = subprocess.check_output(command,
+                                                 stderr=subprocess.STDOUT)
+                
             except (OSError, IOError) as e:
                 # Use FileNotFoundError when python 2 is dropped
                 os_error = e


### PR DESCRIPTION
Work around the well known issue of having to compile a tex to pdf twice. Execute external compiler command twice to from Python.